### PR TITLE
Use 127.0.0.1 as the login URL to avoid mixed content warnings in FF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Use 127.0.0.1 as the login URL to avoid mixed content warnings in FF
+
 ## [1.2.0] - 2017-08-08
 
 - Show the dashboard URL specific to the environment (resin production / staging / other) used for authentication

--- a/build/auth.js
+++ b/build/auth.js
@@ -57,7 +57,7 @@ exports.login = function() {
     port: 8989,
     path: '/auth'
   };
-  callbackUrl = "http://localhost:" + options.port + options.path;
+  callbackUrl = "http://127.0.0.1:" + options.port + options.path;
   return utils.getDashboardLoginURL(callbackUrl).then(function(loginUrl) {
     setTimeout(function() {
       return open(loginUrl);

--- a/build/server.js
+++ b/build/server.js
@@ -151,5 +151,5 @@ exports.runDevServer = function(arg) {
   app.get('/error', function(req, res) {
     return res.status(401).render('error');
   });
-  return console.log('http://localhost:4000');
+  return console.log('http://127.0.0.1:4000');
 };

--- a/build/utils.js
+++ b/build/utils.js
@@ -38,7 +38,7 @@ Promise = require('bluebird');
  * @returns {Promise}
  *
  * @example
- * utils.getDashboardLoginURL('http://localhost:3000').then (url) ->
+ * utils.getDashboardLoginURL('http://127.0.0.1:3000').then (url) ->
  * 	console.log(url)
  */
 

--- a/lib/auth.coffee
+++ b/lib/auth.coffee
@@ -48,7 +48,9 @@ exports.login = ->
 		port: 8989
 		path: '/auth'
 
-	callbackUrl = "http://localhost:#{options.port}#{options.path}"
+	# Needs to be 127.0.0.1 not localhost, because the ip only is whitelisted
+	# from mixed content warnings (as the target of a form in the result page)
+	callbackUrl = "http://127.0.0.1:#{options.port}#{options.path}"
 	return utils.getDashboardLoginURL(callbackUrl).then (loginUrl) ->
 
 		# Leave a bit of time for the

--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -111,4 +111,4 @@ exports.runDevServer = ({ port }) ->
 	app.get '/error', (req, res) ->
 		res.status(401).render('error')
 
-	console.log('http://localhost:4000')
+	console.log('http://127.0.0.1:4000')

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -30,7 +30,7 @@ Promise = require('bluebird')
 # @returns {Promise}
 #
 # @example
-# utils.getDashboardLoginURL('http://localhost:3000').then (url) ->
+# utils.getDashboardLoginURL('http://127.0.0.1:3000').then (url) ->
 # 	console.log(url)
 ###
 exports.getDashboardLoginURL = (callbackUrl) ->

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -10,7 +10,7 @@ describe 'Utils:', ->
 	describe '.getDashboardLoginURL()', ->
 
 		it 'should eventually be a valid url', (done) ->
-			utils.getDashboardLoginURL('https://localhost:3000/callback').then (loginUrl) ->
+			utils.getDashboardLoginURL('https://127.0.0.1:3000/callback').then (loginUrl) ->
 				m.chai.expect ->
 					url.parse(loginUrl)
 				.to.not.throw(Error)
@@ -19,7 +19,7 @@ describe 'Utils:', ->
 		it 'should eventually contain an https protocol', (done) ->
 			Promise.props
 				dashboardUrl: resin.settings.get('dashboardUrl')
-				loginUrl: utils.getDashboardLoginURL('https://localhost:3000/callback')
+				loginUrl: utils.getDashboardLoginURL('https://127.0.0.1:3000/callback')
 			.then ({ dashboardUrl, loginUrl }) ->
 				protocol = url.parse(loginUrl).protocol
 				m.chai.expect(protocol).to.equal(url.parse(dashboardUrl).protocol)
@@ -28,18 +28,18 @@ describe 'Utils:', ->
 		it 'should correctly escape a callback url without a path', (done) ->
 			Promise.props
 				dashboardUrl: resin.settings.get('dashboardUrl')
-				loginUrl: utils.getDashboardLoginURL('http://localhost:3000')
+				loginUrl: utils.getDashboardLoginURL('http://127.0.0.1:3000')
 			.then ({ dashboardUrl, loginUrl }) ->
-				expectedUrl = "#{dashboardUrl}/login/cli/http%253A%252F%252Flocalhost%253A3000"
+				expectedUrl = "#{dashboardUrl}/login/cli/http%253A%252F%252F127.0.0.1%253A3000"
 				m.chai.expect(loginUrl).to.equal(expectedUrl)
 			.nodeify(done)
 
 		it 'should correctly escape a callback url with a path', (done) ->
 			Promise.props
 				dashboardUrl: resin.settings.get('dashboardUrl')
-				loginUrl: utils.getDashboardLoginURL('http://localhost:3000/callback')
+				loginUrl: utils.getDashboardLoginURL('http://127.0.0.1:3000/callback')
 			.then ({ dashboardUrl, loginUrl }) ->
-				expectedUrl = "#{dashboardUrl}/login/cli/http%253A%252F%252Flocalhost%253A3000%252Fcallback"
+				expectedUrl = "#{dashboardUrl}/login/cli/http%253A%252F%252F127.0.0.1%253A3000%252Fcallback"
 				m.chai.expect(loginUrl).to.equal(expectedUrl)
 			.nodeify(done)
 


### PR DESCRIPTION
See https://github.com/resin-io/resin-ui/pull/1276 for context.

We can't merge this until the callback URL check is fixed in the dashboard in production.