### PR TITLE
Deprecate resin-cli-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+- Deprecate project, as it has been moved into the CLI itself
+
 ## [1.2.1] - 2017-09-25
 
 - Use 127.0.0.1 as the login URL to avoid mixed content warnings in FF

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Join our online chat at [![Gitter chat](https://badges.gitter.im/resin-io/chat.p
 
 Resin.io CLI authentication handler.
 
+This package is now deprecated
+====
+
+Resin-cli-auth is now built into [Resin CLI](https://github.com/resin-io/resin-cli) itself, so this package is not maintained, and should not be used.
+
 Role
 ----
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "resin-cli-auth",
   "version": "1.2.1",
-  "description": "Resin.io CLI authentication handler",
+  "description": "DEPRECATED - Resin.io CLI authentication handler",
   "main": "build/auth.js",
   "homepage": "https://github.com/resin-io/resin-cli-auth",
   "repository": {


### PR DESCRIPTION
With https://github.com/resin-io/resin-cli/pull/721 now merged & released, this module can disappear.

Once this is merged, I'll publish a final release (to update the readme on npm), and then [`npm deprecate`](https://docs.npmjs.com/cli/deprecate) it.